### PR TITLE
refactor: return structured command results and unify API error handling

### DIFF
--- a/comment.en.yaml
+++ b/comment.en.yaml
@@ -13,6 +13,8 @@ task:
     Task score and other information cannot be modified after the task is completed.
   taskNotFound: >
     The task has not been created yet. Please use the "R2CN-score" label to create a task first.
+  apiUnavailable: >
+    The backend API service is unavailable. Please try again later.
   scoreUndefinedComment: >
     Please use the "R2CN-score" label to create a task. The score in the current label is incorrect.
   scoreInvalidComment: >

--- a/comment.zh.yaml
+++ b/comment.zh.yaml
@@ -13,6 +13,8 @@ task:
     任务完成后无法修改分值等信息.
   taskNotFound: >
     任务还未创建,需要使用“R2CN-分值”标签先创建任务.
+  apiUnavailable: >
+    当前后端 API 服务不可用，请稍后重试。
   scoreUndefinedComment: >
     请使用“R2CN-分值”标签来创建任务,当前标签的分值不正确.
   scoreInvalidComment: >

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -45,6 +45,7 @@ interface TaskComment {
     successUpdate: string,
     notAllowedModify: string,
     taskNotFound: string,
+    apiUnavailable: string,
     scoreUndefinedComment: string,
     multiScoreLabel: string,
     scoreInvalidComment: string,

--- a/src/handlers/on-issue-comment-created.ts
+++ b/src/handlers/on-issue-comment-created.ts
@@ -47,8 +47,30 @@ export async function onIssueCommentCreated(
         return;
     }
 
-    const task = await Task.getTask(event.issue.id, event.repo.provider);
+    const taskLookup = await Task.getTaskLookup(event.issue.id, event.repo.provider);
+    const task = taskLookup.task;
     if (task == null) {
+        if (taskLookup.apiError) {
+            log.warn(
+                {
+                    handlerDecision: "task_lookup_api_error",
+                    repoFullName: event.repo.fullName,
+                    issueNumber: event.issue.number,
+                    issueInternalId: event.issue.id,
+                    apiMessage: taskLookup.message,
+                    commandPreview: command.slice(0, 80),
+                },
+                "onIssueCommentCreated: task lookup API failed; posting apiUnavailable",
+            );
+            await scm.createIssueComment({
+                owner,
+                repo: repoName,
+                issueNumber,
+                body: config.comment.task.apiUnavailable,
+                ...p,
+            });
+            return;
+        }
         log.info(
             {
                 handlerDecision: "task_not_found_will_still_evaluate_command",
@@ -66,6 +88,18 @@ export async function onIssueCommentCreated(
             body: config.comment.task.taskNotFound,
             ...p,
         });
+        if (command.startsWith("/request")) {
+            log.info(
+                {
+                    handlerDecision: "task_not_found_return_after_comment",
+                    repoFullName: event.repo.fullName,
+                    issueNumber: event.issue.number,
+                    commandPreview: command.slice(0, 80),
+                },
+                "onIssueCommentCreated: task missing for /request*; return after taskNotFound comment",
+            );
+            return;
+        }
     }
 
     if (command.startsWith("/request")) {
@@ -86,6 +120,16 @@ export async function onIssueCommentCreated(
             task,
             scmProvider: event.repo.provider,
         });
+        if (res.apiError) {
+            await scm.createIssueComment({
+                owner,
+                repo: repoName,
+                issueNumber,
+                body: config.comment.task.apiUnavailable,
+                ...p,
+            });
+            return;
+        }
         await scm.createIssueComment({
             owner,
             repo: repoName,
@@ -111,6 +155,16 @@ export async function onIssueCommentCreated(
             task,
             scmProvider: event.repo.provider,
         });
+        if (res.apiError) {
+            await scm.createIssueComment({
+                owner,
+                repo: repoName,
+                issueNumber,
+                body: config.comment.task.apiUnavailable,
+                ...p,
+            });
+            return;
+        }
         await scm.createIssueComment({
             owner,
             repo: repoName,

--- a/src/handlers/on-issue-labeled.ts
+++ b/src/handlers/on-issue-labeled.ts
@@ -160,8 +160,29 @@ export async function onIssueLabeled(
         return;
     }
 
-    const task = await Task.getTask(event.issue.id, event.repo.provider);
+    const taskLookup = await Task.getTaskLookup(event.issue.id, event.repo.provider);
+    const task = taskLookup.task;
     if (task == null) {
+        if (taskLookup.apiError) {
+            log.warn(
+                {
+                    handlerDecision: "task_lookup_api_error_reply_api_unavailable",
+                    repoFullName,
+                    issueNumber,
+                    issueInternalId: event.issue.id,
+                    apiMessage: taskLookup.message,
+                },
+                "onIssueLabeled: task lookup API failed → apiUnavailable",
+            );
+            await scm.createIssueComment({
+                owner,
+                repo: repoName,
+                issueNumber,
+                body: config.comment.task.apiUnavailable,
+                ...p,
+            });
+            return;
+        }
         log.info(
             {
                 handlerDecision: "task_branch_no_existing_task",
@@ -188,7 +209,7 @@ export async function onIssueLabeled(
                 },
                 event.repo.provider,
             );
-            if (newTaskRes) {
+            if (newTaskRes.ok) {
                 log.info(
                     {
                         handlerDecision: "reply_new_task_success",
@@ -210,9 +231,20 @@ export async function onIssueLabeled(
                         handlerDecision: "new_task_failed_no_comment",
                         repoFullName,
                         issueNumber,
+                        apiError: newTaskRes.apiError,
+                        apiMessage: newTaskRes.message,
                     },
-                    "onIssueLabeled: checkTask passed but newTask returned false; no success comment",
+                    "onIssueLabeled: checkTask passed but newTask returned false",
                 );
+                await scm.createIssueComment({
+                    owner,
+                    repo: repoName,
+                    issueNumber,
+                    body: newTaskRes.apiError
+                        ? config.comment.task.apiUnavailable
+                        : config.comment.command.invalidTaskState,
+                    ...p,
+                });
             }
         } else {
             log.info(
@@ -227,7 +259,7 @@ export async function onIssueLabeled(
                 owner,
                 repo: repoName,
                 issueNumber,
-                body: checkRes.message,
+                body: checkRes.apiError ? config.comment.task.apiUnavailable : checkRes.message,
                 ...p,
             });
         }
@@ -259,7 +291,19 @@ export async function onIssueLabeled(
                 },
                 "onIssueLabeled: updating task score and posting successUpdate",
             );
-            await Task.updateTaskScore(event.issue, score, event.repo.provider);
+            const updateRes = await Task.updateTaskScore(event.issue, score, event.repo.provider);
+            if (!updateRes.ok) {
+                await scm.createIssueComment({
+                    owner,
+                    repo: repoName,
+                    issueNumber,
+                    body: updateRes.apiError
+                        ? config.comment.task.apiUnavailable
+                        : config.comment.command.invalidTaskState,
+                    ...p,
+                });
+                return;
+            }
             await scm.createIssueComment({
                 owner,
                 repo: repoName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,42 @@ import {
 import { dispatchCanonicalEvent } from "./webhooks/event-router.js";
 import { mountAtomgitWebhookIfPresent } from "./webhooks/atomgit-webhook-route.js";
 
+let atomgitProxyStarted = false;
 
-export default (app: Probot, options: unknown) => {
+async function startAtomgitWebhookProxyIfConfigured(app: Probot): Promise<void> {
+    const source = process.env.ATOMGIT_WEBHOOK_PROXY_URL?.trim() ?? "";
+    if (source === "") {
+        return;
+    }
+    if (atomgitProxyStarted) {
+        return;
+    }
+
+    const port = process.env.PORT?.trim() || "3000";
+    const host = process.env.HOST?.trim() || "localhost";
+    const target = `http://${host}:${port}/webhooks/atomgit`;
+    try {
+        const { default: SmeeClient } = await import("smee-client");
+        const smee = new SmeeClient({
+            source,
+            target,
+            logger: {
+                info: (...args: unknown[]) => app.log.info({ source, target }, String(args[0] ?? "Atomgit smee info")),
+                error: (...args: unknown[]) => app.log.error({ source, target }, String(args[0] ?? "Atomgit smee error")),
+            },
+        });
+        await smee.start();
+        atomgitProxyStarted = true;
+        app.log.info({ source, target }, "Atomgit smee proxy started");
+    } catch (err) {
+        app.log.error({ err, source, target }, "Failed to start Atomgit smee proxy");
+    }
+}
+
+
+export default async (app: Probot, options: unknown) => {
     mountAtomgitWebhookIfPresent(app, options);
+    await startAtomgitWebhookProxyIfConfigured(app);
     app.log.info(`api endpoint: ${process.env.API_ENDPOINT}`);
 
     app.onAny(async (event) => {

--- a/src/mentor/index.ts
+++ b/src/mentor/index.ts
@@ -6,6 +6,28 @@ import { releaseTask } from "../student/index.js";
 import type { ScmClient } from "../scm/types.js";
 import { scmProjectOptsFromTask } from "../handlers/scm-project-opts.js";
 import { mergeBackendWithTask } from "../api/scm-backend-payload.js";
+import type { TaskApiResult } from "../task/index.js";
+
+export type MentorCommandBusinessCode =
+    | "invalid_task_state"
+    | "no_permission"
+    | "intern_disapprove_success"
+    | "intern_approve_success"
+    | "intern_fail_success"
+    | "intern_done_success"
+    | "intern_close_success"
+    | "intern_approve_failed"
+    | "intern_done_failed"
+    | "intern_close_failed"
+    | "unsupported_mentor_command"
+    | "api_error";
+
+export interface MentorCommandResult {
+    result: boolean;
+    message: string;
+    apiError: boolean;
+    businessCode: MentorCommandBusinessCode;
+}
 
 export interface Payload {
     actor: Actor,
@@ -17,20 +39,31 @@ export interface Payload {
 }
 
 export async function handle_mentor_cmd(scm: ScmClient, config: Config, payload: Payload) {
-    var command_res = {
+    var command_res: MentorCommandResult = {
         result: false,
         message: "",
+        apiError: false,
+        businessCode: "invalid_task_state",
     };
     const { actor, command, task, scmProvider } = payload;
     if (task == null) {
         return {
             result: false,
             message: config.comment.command.invalidTaskState,
+            apiError: false,
+            businessCode: "invalid_task_state",
         };
     }
-    const setResponse = (message: string, result: boolean = false) => {
+    const setResponse = (
+        message: string,
+        businessCode: MentorCommandBusinessCode,
+        result: boolean = false,
+        apiError: boolean = false,
+    ) => {
         command_res.message = message;
         command_res.result = result;
+        command_res.businessCode = businessCode;
+        command_res.apiError = apiError;
         return command_res;
     };
 
@@ -39,7 +72,7 @@ export async function handle_mentor_cmd(scm: ScmClient, config: Config, payload:
     };
 
     if (!isMentorAuthorized(task, actor)) {
-        return setResponse(config.comment.command.noPermission);
+        return setResponse(config.comment.command.noPermission, "no_permission");
     }
 
     const req = {
@@ -49,16 +82,22 @@ export async function handle_mentor_cmd(scm: ScmClient, config: Config, payload:
     switch (command) {
         case "/intern-disapprove":
             if (task.task_status !== TaskStatus.RequestAssign) {
-                return setResponse(config.comment.command.invalidTaskState);
+                return setResponse(config.comment.command.invalidTaskState, "invalid_task_state");
             }
             await releaseTask(req, scm, payload);
-            return setResponse(config.comment.internDisapprove.success, true);
+            return setResponse(config.comment.internDisapprove.success, "intern_disapprove_success", true);
 
         case "/intern-approve":
             if (task.task_status !== TaskStatus.RequestAssign) {
-                return setResponse(config.comment.command.invalidTaskState);
+                return setResponse(config.comment.command.invalidTaskState, "invalid_task_state");
             }
-            await internApprove(req, task, scmProvider);
+            const approveRes = await internApprove(req, task, scmProvider);
+            if (approveRes.apiError) {
+                return setResponse(config.comment.task.apiUnavailable, "api_error", false, true);
+            }
+            if (!approveRes.ok) {
+                return setResponse(config.comment.command.invalidTaskState, "intern_approve_failed");
+            }
             const claimedLabel = getClaimedLabelName(task.owner, task.repo);
             await scm.addLabels({
                 owner: task.owner,
@@ -76,11 +115,11 @@ export async function handle_mentor_cmd(scm: ScmClient, config: Config, payload:
                     ...tp,
                 });
             }
-            return setResponse(config.comment.internApprove.success, true);
+            return setResponse(config.comment.internApprove.success, "intern_approve_success", true);
 
         case "/intern-fail":
             if (task.task_status !== TaskStatus.Assigned) {
-                return setResponse(config.comment.command.invalidTaskState);
+                return setResponse(config.comment.command.invalidTaskState, "invalid_task_state");
             }
             if (task.student_login) {
                 await scm.removeAssignees({
@@ -93,10 +132,10 @@ export async function handle_mentor_cmd(scm: ScmClient, config: Config, payload:
             }
             await releaseTask(req, scm, payload);
 
-            return setResponse(config.comment.internFail.success, true);
+            return setResponse(config.comment.internFail.success, "intern_fail_success", true);
         case "/intern-done":
             if (task.task_status !== TaskStatus.RequestFinish) {
-                return setResponse(config.comment.command.invalidTaskState);
+                return setResponse(config.comment.command.invalidTaskState, "invalid_task_state");
             }
             await scm.updateIssue({
                 owner: task.owner,
@@ -112,8 +151,14 @@ export async function handle_mentor_cmd(scm: ScmClient, config: Config, payload:
                 labels: ["r2cn-complete"],
                 ...tp,
             });
-            await internDone(req, task, scmProvider);
-            return setResponse(config.comment.internDone.success, true);
+            const doneRes = await internDone(req, task, scmProvider);
+            if (doneRes.apiError) {
+                return setResponse(config.comment.task.apiUnavailable, "api_error", false, true);
+            }
+            if (!doneRes.ok) {
+                return setResponse(config.comment.command.invalidTaskState, "intern_done_failed");
+            }
+            return setResponse(config.comment.internDone.success, "intern_done_success", true);
         case "/intern-close":
             await scm.removeAllLabels({
                 owner: task.owner,
@@ -121,37 +166,55 @@ export async function handle_mentor_cmd(scm: ScmClient, config: Config, payload:
                 issueNumber: task.issue_number,
                 ...tp,
             });
-            await internClose(req, task, scmProvider);
-            return setResponse(config.comment.internClose.success, true);
+            const closeRes = await internClose(req, task, scmProvider);
+            if (closeRes.apiError) {
+                return setResponse(config.comment.task.apiUnavailable, "api_error", false, true);
+            }
+            if (!closeRes.ok) {
+                return setResponse(config.comment.command.invalidTaskState, "intern_close_failed");
+            }
+            return setResponse(config.comment.internClose.success, "intern_close_success", true);
         default:
-            return setResponse(config.comment.command.unsupportMentorCommand);
+            return setResponse(config.comment.command.unsupportMentorCommand, "unsupported_mentor_command");
     }
 }
 
 
 async function internApprove(req: CommandRequest, task: Task, scmProvider: ScmProvider) {
+    const isApiError = <T>(res: { message: string; data: T | null }) =>
+        res.data == null && res.message !== "success";
     const body = mergeBackendWithTask(req, scmProvider, task);
     const apiUrl = `${process.env.API_ENDPOINT}/task/intern-approve`;
-    const res = await postData<boolean, typeof body>(apiUrl, body).then((res) => {
-        return res.data
-    });
-    return res
+    const apiRes = await postData<boolean, typeof body>(apiUrl, body);
+    return {
+        ok: apiRes.data === true,
+        apiError: isApiError(apiRes),
+        message: apiRes.message,
+    } as TaskApiResult;
 }
 
 async function internDone(req: CommandRequest, task: Task, scmProvider: ScmProvider) {
+    const isApiError = <T>(res: { message: string; data: T | null }) =>
+        res.data == null && res.message !== "success";
     const body = mergeBackendWithTask(req, scmProvider, task);
     const apiUrl = `${process.env.API_ENDPOINT}/task/intern-done`;
-    const res = await postData<boolean, typeof body>(apiUrl, body).then((res) => {
-        return res.data
-    });
-    return res
+    const apiRes = await postData<boolean, typeof body>(apiUrl, body);
+    return {
+        ok: apiRes.data === true,
+        apiError: isApiError(apiRes),
+        message: apiRes.message,
+    } as TaskApiResult;
 }
 
 async function internClose(req: CommandRequest, task: Task, scmProvider: ScmProvider) {
+    const isApiError = <T>(res: { message: string; data: T | null }) =>
+        res.data == null && res.message !== "success";
     const body = mergeBackendWithTask(req, scmProvider, task);
     const apiUrl = `${process.env.API_ENDPOINT}/task/intern-close`;
-    const res = await postData<boolean, typeof body>(apiUrl, body).then((res) => {
-        return res.data
-    });
-    return res
+    const apiRes = await postData<boolean, typeof body>(apiUrl, body);
+    return {
+        ok: apiRes.data === true,
+        apiError: isApiError(apiRes),
+        message: apiRes.message,
+    } as TaskApiResult;
 }

--- a/src/student/index.ts
+++ b/src/student/index.ts
@@ -10,22 +10,55 @@ import {
     mergeBackendWithTask,
     type ScmBackendRequestFields,
 } from "../api/scm-backend-payload.js";
+import type { TaskApiResult } from "../task/index.js";
+
+export type StudentCommandBusinessCode =
+    | "invalid_task_state"
+    | "claim_by_other"
+    | "waiting_info_review"
+    | "already_claimed_by_same_student"
+    | "existing_active_task"
+    | "request_assign_success"
+    | "request_assign_failed"
+    | "no_permission"
+    | "request_complete_success"
+    | "request_complete_failed"
+    | "request_release_success"
+    | "request_release_failed"
+    | "unsupported_student_command"
+    | "api_error";
+
+export interface StudentCommandResult {
+    result: boolean;
+    message: string;
+    apiError: boolean;
+    businessCode: StudentCommandBusinessCode;
+}
 
 export async function handle_stu_cmd(scm: ScmClient, config: Config, payload: Payload) {
-    var command_res = {
+    var command_res: StudentCommandResult = {
         result: false,
         message: "",
+        apiError: false,
+        businessCode: "invalid_task_state",
     };
     const { actor, command, task, scmProvider } = payload;
 
-    const setResponse = (message: string, result: boolean = false) => {
+    const setResponse = (
+        message: string,
+        businessCode: StudentCommandBusinessCode,
+        result: boolean = false,
+        apiError: boolean = false,
+    ) => {
         command_res.message = message;
         command_res.result = result;
+        command_res.businessCode = businessCode;
+        command_res.apiError = apiError;
         return command_res;
     };
 
     if (task == null) {
-        return setResponse(config.comment.command.invalidTaskState);
+        return setResponse(config.comment.command.invalidTaskState, "invalid_task_state");
     }
 
     const isStudentAuthorized = (task: Task, student: Actor) => {
@@ -40,17 +73,20 @@ export async function handle_stu_cmd(scm: ScmClient, config: Config, payload: Pa
     switch (command) {
         case "/request-assign":
             if (task.task_status == TaskStatus.RequestAssign) {
-                return setResponse(config.comment.requestAssign.claimByOther);
+                return setResponse(config.comment.requestAssign.claimByOther, "claim_by_other");
             }
 
             if (task.task_status !== TaskStatus.Open) {
-                return setResponse(config.comment.command.invalidTaskState);
+                return setResponse(config.comment.command.invalidTaskState, "invalid_task_state");
             }
 
             // 学生身份校验
             const verify = await verifyStudentIdentity(actor.login, scmProvider);
-            if (!verify.success) {
-                return setResponse(config.comment.requestAssign.waitingInfoReview);
+            if (verify.apiError) {
+                return setResponse(config.comment.task.apiUnavailable, "api_error", false, true);
+            }
+            if (!verify.data?.success) {
+                return setResponse(config.comment.requestAssign.waitingInfoReview, "waiting_info_review");
             }
 
             // 合同签署校验
@@ -59,25 +95,33 @@ export async function handle_stu_cmd(scm: ScmClient, config: Config, payload: Pa
             // }
 
             if (task.student_login === actor.login) {
-                return setResponse(config.comment.requestAssign.alreadyClaim);
+                return setResponse(config.comment.requestAssign.alreadyClaim, "already_claimed_by_same_student");
             }
 
-            if (!await verifyStudentTask(actor.login, scmProvider)) {
-                return setResponse(config.comment.requestAssign.existTask);
+            const taskCheck = await verifyStudentTask(actor.login, scmProvider);
+            if (taskCheck.apiError) {
+                return setResponse(config.comment.task.apiUnavailable, "api_error", false, true);
+            }
+            if (!taskCheck.allow) {
+                return setResponse(config.comment.requestAssign.existTask, "existing_active_task");
             }
 
-            if (await requestAssign(req, task, scmProvider)) {
-                return setResponse(config.comment.requestAssign.success, true);
+            const assignRes = await requestAssign(req, task, scmProvider);
+            if (assignRes.apiError) {
+                return setResponse(config.comment.task.apiUnavailable, "api_error", false, true);
+            }
+            if (assignRes.ok) {
+                return setResponse(config.comment.requestAssign.success, "request_assign_success", true);
             } else {
-                return setResponse("API ERROR");
+                return setResponse(config.comment.command.invalidTaskState, "request_assign_failed");
             }
         case "/request-complete":
             if (task.task_status !== TaskStatus.Assigned) {
-                return setResponse(config.comment.command.invalidTaskState);
+                return setResponse(config.comment.command.invalidTaskState, "invalid_task_state");
             }
 
             if (!isStudentAuthorized(task, actor)) {
-                return setResponse(config.comment.command.noPermission);
+                return setResponse(config.comment.command.noPermission, "no_permission");
             }
 
             //check related PRs
@@ -90,23 +134,35 @@ export async function handle_stu_cmd(scm: ScmClient, config: Config, payload: Pa
             // if (res.data.pull_request == undefined) {
             //     return setResponse(config.requestComplete.noRelatedPR);
             // }
-            await requestComplete(req, task, scmProvider)
-            return setResponse(config.comment.requestComplete.success, true);
+            const completeRes = await requestComplete(req, task, scmProvider);
+            if (completeRes.apiError) {
+                return setResponse(config.comment.task.apiUnavailable, "api_error", false, true);
+            }
+            if (!completeRes.ok) {
+                return setResponse(config.comment.command.invalidTaskState, "request_complete_failed");
+            }
+            return setResponse(config.comment.requestComplete.success, "request_complete_success", true);
 
         case "/request-release":
             if (task.task_status !== TaskStatus.Assigned) {
-                return setResponse(config.comment.command.invalidTaskState);
+                return setResponse(config.comment.command.invalidTaskState, "invalid_task_state");
             }
 
             if (!isStudentAuthorized(task, actor)) {
-                return setResponse(config.comment.command.noPermission);
+                return setResponse(config.comment.command.noPermission, "no_permission");
             }
 
-            await releaseTask(req, scm, payload)
-            return setResponse(config.comment.requestRelease.success, true);
+            const releaseRes = await releaseTask(req, scm, payload);
+            if (releaseRes.apiError) {
+                return setResponse(config.comment.task.apiUnavailable, "api_error", false, true);
+            }
+            if (!releaseRes.ok) {
+                return setResponse(config.comment.command.invalidTaskState, "request_release_failed");
+            }
+            return setResponse(config.comment.requestRelease.success, "request_release_success", true);
 
         default:
-            return setResponse(config.comment.command.unsupportStuCommand);
+            return setResponse(config.comment.command.unsupportStuCommand, "unsupported_student_command");
     }
 }
 
@@ -121,22 +177,28 @@ interface VerifyStuRes {
     contract_deadline?: string,
 }
 
+function isApiError<T>(res: { message: string; data: T | null }): boolean {
+    return res.data == null && res.message !== "success";
+}
+
 async function verifyStudentIdentity(login: string, scmProvider: Payload["scmProvider"]) {
     const apiUrl = `${process.env.API_ENDPOINT}/student/validate`;
     const body: UserReq & ScmBackendRequestFields = mergeBackendProviderOnly({ login }, scmProvider);
-    const res = await postData<VerifyStuRes, typeof body>(apiUrl, body).then((res) => {
-        return res.data
-    });
-    return res
+    const apiRes = await postData<VerifyStuRes, typeof body>(apiUrl, body);
+    return {
+        data: apiRes.data ?? null,
+        apiError: isApiError(apiRes),
+    };
 }
 
 async function verifyStudentTask(login: string, scmProvider: Payload["scmProvider"]) {
     const apiUrl = `${process.env.API_ENDPOINT}/student/task`;
     const body: UserReq & ScmBackendRequestFields = mergeBackendProviderOnly({ login }, scmProvider);
-    const res = await postData<Task, typeof body>(apiUrl, body).then((res) => {
-        return res.data
-    });
-    return res === null
+    const apiRes = await postData<Task, typeof body>(apiUrl, body);
+    if (isApiError(apiRes)) {
+        return { allow: false, apiError: true };
+    }
+    return { allow: apiRes.data === null, apiError: false };
 }
 
 
@@ -144,16 +206,22 @@ async function verifyStudentTask(login: string, scmProvider: Payload["scmProvide
 async function requestAssign(req: CommandRequest, task: Task, scmProvider: Payload["scmProvider"]) {
     const apiUrl = `${process.env.API_ENDPOINT}/task/request-assign`;
     const body = mergeBackendWithTask(req, scmProvider, task);
-    const res = await postData<boolean, typeof body>(apiUrl, body).then((res) => {
-        return res.data
-    });
-    return res
+    const apiRes = await postData<boolean, typeof body>(apiUrl, body);
+    return {
+        ok: apiRes.data === true,
+        apiError: isApiError(apiRes),
+        message: apiRes.message,
+    } as TaskApiResult;
 }
 
 export async function releaseTask(req: CommandRequest, scm: ScmClient, payload: Payload) {
     const { task, issueLabels, scmProvider } = payload;
     if (task == null) {
-        return false;
+        return {
+            ok: false,
+            apiError: false,
+            message: "task_not_found",
+        } as TaskApiResult;
     }
     const claimedLabel = getClaimedLabelName(task.owner, task.repo);
     const existingLabels = issueLabels.some(label => label.name === claimedLabel);
@@ -178,10 +246,12 @@ export async function releaseTask(req: CommandRequest, scm: ScmClient, payload: 
     }
     const apiUrl = `${process.env.API_ENDPOINT}/task/release`;
     const body = mergeBackendWithTask(req, scmProvider, task);
-    const res = await postData<boolean, typeof body>(apiUrl, body).then((res) => {
-        return res.data
-    });
-    return res
+    const apiRes = await postData<boolean, typeof body>(apiUrl, body);
+    return {
+        ok: apiRes.data === true,
+        apiError: isApiError(apiRes),
+        message: apiRes.message,
+    } as TaskApiResult;
 }
 
 async function requestComplete(
@@ -191,8 +261,10 @@ async function requestComplete(
 ) {
     const apiUrl = `${process.env.API_ENDPOINT}/task/request-complete`;
     const body = mergeBackendWithTask(req, scmProvider, task);
-    const res = await postData<boolean, typeof body>(apiUrl, body).then((res) => {
-        return res.data
-    });
-    return res
+    const apiRes = await postData<boolean, typeof body>(apiUrl, body);
+    return {
+        ok: apiRes.data === true,
+        apiError: isApiError(apiRes),
+        message: apiRes.message,
+    } as TaskApiResult;
 }

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -16,6 +16,18 @@ export interface Task {
     mentor_login: string,
 }
 
+export interface TaskLookupResult {
+    task: Task | null;
+    apiError: boolean;
+    message: string;
+}
+
+export interface TaskApiResult {
+    ok: boolean;
+    apiError: boolean;
+    message: string;
+}
+
 export enum TaskStatus {
     Open = "Open",
     Invalid = "Invalid",
@@ -25,13 +37,32 @@ export enum TaskStatus {
     Finished = "Finished",
 }
 
-export async function getTask(issue_id: number, provider: ScmProvider) {
+export async function getTaskLookup(issue_id: number, provider: ScmProvider): Promise<TaskLookupResult> {
     const base = `${process.env.API_ENDPOINT}/task/issue/${issue_id}`;
     const url = `${base}?${new URLSearchParams({ scm_provider: provider }).toString()}`;
-    const res = await fetchData<Task>(url).then((res) => {
-        return res.data
+    const apiRes = await fetchData<Task>(url);
+    const res = apiRes.data;
+    const apiError = res == null && apiRes.message !== "success";
+    console.info("[task/getTask] result", {
+        issue_id,
+        provider,
+        hasTask: res != null,
+        apiError,
+        apiMessage: apiRes.message,
+        task_status: res?.task_status,
+        mentor_login: res?.mentor_login,
+        student_login: res?.student_login,
     });
-    return res
+    return {
+        task: res ?? null,
+        apiError,
+        message: apiRes.message,
+    };
+}
+
+export async function getTask(issue_id: number, provider: ScmProvider) {
+    const lookup = await getTaskLookup(issue_id, provider);
+    return lookup.task;
 }
 
 type TaskCreateBase = {
@@ -65,7 +96,7 @@ function requireRepoNumericId(repo: RepoRef, op: string): number {
 export async function newTask(
     input: NewTaskInput,
     provider: ScmProvider,
-) {
+): Promise<TaskApiResult> {
     const { repo, issue, mentor, score } = input;
     const repoId = requireRepoNumericId(repo, "newTask");
     const req: TaskCreateRequest = {
@@ -85,14 +116,13 @@ export async function newTask(
         }),
     };
     const apiUrl = `${process.env.API_ENDPOINT}/task/new`;
-    const res = await postData<Task[], typeof req>(apiUrl, req).then((res) => {
-        return res.data
-    });
-    if (res != undefined) {
-        return true
-    } else {
-        return false
-    }
+    const apiRes = await postData<Task[], typeof req>(apiUrl, req);
+    const apiError = apiRes.data == null && apiRes.message !== "success";
+    return {
+        ok: apiRes.data != null,
+        apiError,
+        message: apiRes.message,
+    };
 }
 
 interface TaskUpdate {
@@ -110,20 +140,20 @@ export async function updateTaskScore(issue: IssueRef, score: number, provider: 
     } as TaskUpdate & ReturnType<typeof scmBackendFields>;
 
     const apiUrl = `${process.env.API_ENDPOINT}/task/update-score`;
-    const res = await postData<boolean, typeof req>(apiUrl, req).then((res) => {
-        return res.data
-    });
-    if (res != undefined) {
-        return true
-    } else {
-        return false
-    }
+    const apiRes = await postData<boolean, typeof req>(apiUrl, req);
+    const apiError = apiRes.data == null && apiRes.message !== "success";
+    return {
+        ok: apiRes.data != null,
+        apiError,
+        message: apiRes.message,
+    } as TaskApiResult;
 }
 
 
 export interface CheckTaskResults {
     result: boolean,
     message: string,
+    apiError: boolean,
 }
 
 export async function checkTask(
@@ -136,6 +166,7 @@ export async function checkTask(
     var fail_res = {
         result: false,
         message: "",
+        apiError: false,
     };
 
     const apiUrl = `${process.env.API_ENDPOINT}/task/search`;
@@ -147,9 +178,23 @@ export async function checkTask(
             fullName: repo.fullName,
         }),
     }
-    const tasks = await postData<Task[], typeof req>(apiUrl, req).then((res) => {
-        return res.data
-    });
+    const apiRes = await postData<Task[], typeof req>(apiUrl, req);
+    const apiError = apiRes.data == null && apiRes.message !== "success";
+    if (apiError) {
+        console.warn("[task/search] api error", {
+            repo_id: repoId,
+            mentor_login: maintainer.id,
+            provider,
+            apiUrl,
+            message: apiRes.message,
+        });
+        return {
+            result: false,
+            message: "task_search_api_error",
+            apiError: true,
+        };
+    }
+    const tasks = apiRes.data;
     if (tasks == null) {
         console.warn("[task/search] backend returned null, fallback to empty task list", {
             repo_id: repoId,
@@ -162,11 +207,13 @@ export async function checkTask(
 
     if (safeTasks.length >= maintainer.task) {
         fail_res.message = config.comment.task.userToomanyTask;
+        fail_res.apiError = false;
         return fail_res
     }
 
     return {
         result: true,
         message: "",
+        apiError: false,
     }
 }

--- a/src/webhooks/atomgit-webhook-route.ts
+++ b/src/webhooks/atomgit-webhook-route.ts
@@ -205,16 +205,59 @@ export function registerAtomgitWebhookRoutes(
     );
 }
 
+export function registerHealthzRoute(router: Router): void {
+    router.get("/healthz", (_req: Request, res: Response) => {
+        res.status(200).json({ ok: true });
+    });
+}
+
 /**
  * Mount Atomgit webhook when `getRouter` is available (Probot server).
  */
 export function mountAtomgitWebhookIfPresent(app: Probot, options: unknown): void {
     const getRouter = (options as { getRouter?: (path?: string) => Router }).getRouter;
+    const addHandler = (
+        options as {
+            addHandler?: (handler: (req: Request, res: Response) => boolean | void | Promise<boolean | void>) => void;
+        }
+    ).addHandler;
+
+    if (addHandler !== undefined) {
+        const customApp = express();
+        registerHealthzRoute(customApp);
+        const atomgitRouter = express.Router();
+        registerAtomgitWebhookRoutes(atomgitRouter, app.log);
+        customApp.use("/webhooks/atomgit", atomgitRouter);
+        try {
+            addHandler((req, res) => {
+                const url = req.url ?? "";
+                const isHealthz = url === "/healthz" || url.startsWith("/healthz?");
+                const isAtomgit = url === "/webhooks/atomgit" || url.startsWith("/webhooks/atomgit?");
+                if (!isHealthz && !isAtomgit) {
+                    return false;
+                }
+                customApp(req, res);
+                return true;
+            });
+            app.log.info("healthz mounted at GET /healthz");
+            app.log.info("Atomgit webhook mounted at POST /webhooks/atomgit");
+            return;
+        } catch (err) {
+            app.log.warn({ err }, "addHandler unavailable at runtime; fallback to getRouter path");
+        }
+    }
+
     if (getRouter === undefined) {
-        app.log.warn("getRouter unavailable: Atomgit /webhooks/atomgit not mounted");
+        if ((process.env.ATOMGIT_WEBHOOK_SECRET ?? "") !== "") {
+            app.log.warn("getRouter unavailable: Atomgit routes (/webhooks/atomgit, /healthz) not mounted");
+        } else {
+            app.log.debug("getRouter unavailable and Atomgit is disabled; skipping Atomgit routes");
+        }
         return;
     }
+    registerHealthzRoute(getRouter());
     const router = getRouter("/webhooks/atomgit");
     registerAtomgitWebhookRoutes(router, app.log);
+    app.log.info("healthz mounted at GET /healthz");
     app.log.info("Atomgit webhook mounted at POST /webhooks/atomgit");
 }

--- a/test/on-issue-comment-created.test.ts
+++ b/test/on-issue-comment-created.test.ts
@@ -64,15 +64,19 @@ describe("onIssueCommentCreated (phase 5)", () => {
             return null;
         });
 
-        vi.spyOn(Task, "getTask").mockResolvedValue({
-            repo: "r",
-            owner: "o",
-            issue_number: 5,
-            repo_id: 99,
-            issue_id: 100,
-            task_status: Task.TaskStatus.Assigned,
-            mentor_login: "m",
-            student_login: "bob",
+        vi.spyOn(Task, "getTaskLookup").mockResolvedValue({
+            task: {
+                repo: "r",
+                owner: "o",
+                issue_number: 5,
+                repo_id: 99,
+                issue_id: 100,
+                task_status: Task.TaskStatus.Assigned,
+                mentor_login: "m",
+                student_login: "bob",
+            },
+            apiError: false,
+            message: "success",
         });
 
         await onIssueCommentCreated(event!, { scm, log: noopLog });


### PR DESCRIPTION
Replace string-based API_ERROR_MESSAGE branching with structured command results from student/mentor handlers, including apiError and businessCode fields for consistent downstream handling